### PR TITLE
fix: drop subscriber when closing connection

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -151,12 +151,13 @@ func (s *serverSession) publish(event string, data interface{}) error {
 	}
 
 	s.Lock()
-	for subId, sub := range s.subscribers {
+	for id, sub := range s.subscribers {
 		select {
 		case sub <- encoded:
 			continue
 		default:
-			log.Printf("[session:%v] subscriber %v non-responsive, closing", s.server.Name, subId)
+			log.Printf("[session:%v] subscriber %v non-responsive, closing", s.server.Name, id)
+			delete(s.subscribers, id)
 			close(sub)
 		}
 	}


### PR DESCRIPTION
The previous fix for handling idle subscribers worked to avoid blocking the channel, but created a new issue when the loop would occasionally re-run on the same set of subscribers and try to write to a now-closed channel, causing a panic. Fixed by removing the subscriber immediately if it's blocking.